### PR TITLE
`make test` was failing to compile when exercise 0 was completed correctly

### DIFF
--- a/answers/EE3b_select.hs
+++ b/answers/EE3b_select.hs
@@ -4,9 +4,8 @@ module EE3b_select where
 
 import Database.Esqueleto.Experimental
 import Database.Esqueleto.Internal.Internal (SqlSelect)
-import Types (DB)
 import Control.Monad.IO.Class
 import Control.Monad.Reader (ReaderT)
 
-b_select :: (SqlSelect a r, MonadIO m, SqlBackendCanRead backend) => _ -> ReaderT backend m _
+b_select :: (SqlSelect a r, MonadIO m, SqlBackendCanRead backend) => SqlQuery a -> ReaderT backend m [r]
 b_select = undefined


### PR DESCRIPTION
When only exercise 0 was being run (as marked by `fdescribe`) with the correct solution `True` (or any solution for that matter), `make test` was failing to compile. These changes fix that issue, but may result in unintended permissiveness of type holes in other exercises? I'm not sure, I haven't looked into the other exercises yet.