### PR TITLE
update ee2d to require all joins and require inner joins

### DIFF
--- a/answers/EE2d_customerGroups.hs
+++ b/answers/EE2d_customerGroups.hs
@@ -9,7 +9,7 @@ import Data.Text (Text)
 import Schema
 import Types
 
-d_customerGroups :: DB [(Text, [Email])]
+d_customerGroups :: DB [(Text, [Text])]
 d_customerGroups = do
   fmap coerce $ select $ do
     (customer :& _ :& customerGroupParent) <- from $
@@ -19,4 +19,4 @@ d_customerGroups = do
         `innerJoin` table @CustomerGroupParent
           `on` (\(_ :& customerLink :& customerGroupParent) -> customerLink.parentId ==. customerGroupParent.id)
     groupBy customerGroupParent.id
-    pure (customerGroupParent.name, maybeArray $ arrayAgg customer.email)
+    pure (customerGroupParent.name, maybeArray $ arrayAgg customer.name)

--- a/answers/EE2d_customerGroups.hs
+++ b/answers/EE2d_customerGroups.hs
@@ -5,10 +5,11 @@ module EE2d_customerGroups where
 import Data.Coerce (coerce)
 import Database.Esqueleto.Experimental
 import Database.Esqueleto.PostgreSQL
+import Data.Text (Text)
 import Schema
 import Types
 
-d_customerGroups :: DB [(CustomerGroupParentId, [CustomerId])]
+d_customerGroups :: DB [(Text, [Email])]
 d_customerGroups = do
   fmap coerce $ select $ do
     (customer :& _ :& customerGroupParent) <- from $
@@ -18,4 +19,4 @@ d_customerGroups = do
         `innerJoin` table @CustomerGroupParent
           `on` (\(_ :& customerLink :& customerGroupParent) -> customerLink.parentId ==. customerGroupParent.id)
     groupBy customerGroupParent.id
-    pure (customerGroupParent.id, maybeArray $ arrayAgg customer.id)
+    pure (customerGroupParent.name, maybeArray $ arrayAgg customer.email)

--- a/exercises/EE2_Join.hs
+++ b/exercises/EE2_Join.hs
@@ -42,7 +42,7 @@ c_largestGroup = _
 
 {-
 For each CustomerGroupParent with at least one customer in it, list its name,
-as well as the emails of all the customers in that group.
+as well as the names of all the customers in that group.
 -}
-d_customerGroups :: DB [(Text, [Email])]
+d_customerGroups :: DB [(Text, [Text])]
 d_customerGroups  = _

--- a/exercises/EE2_Join.hs
+++ b/exercises/EE2_Join.hs
@@ -41,7 +41,8 @@ c_largestGroup :: DB [Entity Customer]
 c_largestGroup = _
 
 {-
-For each CustomerGroupParent, list its ID as well as the IDs of all the customers in that group.
+For each CustomerGroupParent with at least one customer in it, list its name,
+as well as the emails of all the customers in that group.
 -}
-d_customerGroups :: DB [(CustomerGroupParentId, [CustomerId])]
+d_customerGroups :: DB [(Text, [Email])]
 d_customerGroups  = _

--- a/lib/schema.persistentmodels
+++ b/lib/schema.persistentmodels
@@ -31,12 +31,13 @@ Purchase sql=purchases !allColumnsImmutableByDefault
 -- Allows connecting customers together via a CustomerLink
 CustomerGroupParent sql=customer_group_parents
   Id UUID default=uuid_generate_v1mc()
+  name Text
   createdAt UTCTime MigrationOnly
   updatedAt UTCTime MigrationOnly
   deriving Eq Show
 
 -- Connects customers to the groups they're a part of
--- CustomerGroupParent is one-to-many with Customer via CustomerLink
+-- CustomerGroupParent is many-to-many with Customer via CustomerLink
 CustomerLink sql=customer_links
   Id UUID default=uuid_generate_v1mc()
   parentId CustomerGroupParentId OnDeleteCascade

--- a/reset.sql
+++ b/reset.sql
@@ -1396,6 +1396,7 @@ DROP TABLE IF EXISTS customer_group_parents CASCADE;
 
 CREATE TABLE customer_group_parents
   ( id UUID PRIMARY KEY UNIQUE DEFAULT uuid_generate_v1mc()
+  , name TEXT NOT NULL
   , created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
   , updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
   );
@@ -1423,7 +1424,7 @@ CREATE TRIGGER customer_links_update BEFORE UPDATE ON customer_links FOR EACH RO
 GRANT SELECT, UPDATE, INSERT, DELETE ON customer_links to escalatingesqueleto;
 
 
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Flavor Savers') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='daniel208@thompson.me')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='patrick365@vasquez.net')),
@@ -1431,7 +1432,7 @@ INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='william667@harris.org')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='grace957@ivers.com'));
 
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Tuesday Treaters') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='daniel208@thompson.me')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='benjamin641@quinn.net')),
@@ -1439,28 +1440,28 @@ INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='xena989@robinson.net'));
 
 -- single-person groups
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Felix''s Group') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='felix845@young.me'));
 
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Xena''s Group') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='xena989@robinson.net'));
 
 -- empty groups
-INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc());
-INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc());
-INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc());
-INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc());
+INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Ice Cream Haters');
+INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), '1-star Reviewers');
+INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'New Group');
+INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'New Group (1) (How do I delete these???)');
 
 -- daniel group
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Daniel Squad') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='daniel208@thompson.me')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='daniel720@lewis.org')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='daniel825@anderson.net'));
 
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Monday Munchers') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='isabella525@carter.net')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='xena744@harris.net')),
@@ -1471,7 +1472,7 @@ INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='chloe263@young.net'));
 
 -- big group
-WITH parent AS (INSERT INTO customer_group_parents (id) VALUES (uuid_generate_v1mc()) RETURNING id)
+WITH parent AS (INSERT INTO customer_group_parents (id, name) VALUES (uuid_generate_v1mc(), 'Party People') RETURNING id)
 INSERT INTO customer_links VALUES
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='isabella525@carter.net')),
   (uuid_generate_v1mc(), (SELECT id FROM parent), (SELECT id FROM customers WHERE email='xena744@harris.net')),


### PR DESCRIPTION
- The problem as written didn't specify that empty groups should be omitted, which would make left joins the correct choice. In order to not need `arrayRemoveNull` we want to keep it to inner joins, which means changing the problem to omit empty groups
- Using ids meant that it could be solved without any joins. Using names/emails requires actually joining on the parent group and customer tables.
- Also includes a miscellaneous fix to the documentation in the models folder which described group:customer as one to many, when it's actually many to many