### PR TITLE
working ghciwatch implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ psql:
 
 # simple filewatcher that reruns `cabal test` on changes
 watch:
-	fswatch -o exercises/* test/* | (while read -r event; do cabal test; done)
+	fswatch -o exercises/* lib/* answers/* test/* | (while read -r event; do cabal test; done)
 
-	# you could instead use a more advanced watcher like `ghciwatch`
-	# ghciwatch --watch exercises --watch test --enable-eval --clear --test-ghci Main.main
+# close feedback loop with ghciwatch
+ghciwatch:
+	ghciwatch --watch exercises --watch lib --watch answers --watch test --enable-eval --clear --error-file ghcid.txt --test-ghci Main.main --command "cabal repl escalating-esqueleto-test"
 
-.PHONY: test watch
+.PHONY: test watch ghciwatch

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,15 @@ psql:
 
 # close feedback loop with ghciwatch
 ghciwatch:
-	ghciwatch --watch exercises --watch lib --watch answers --watch test --enable-eval --clear --error-file ghcid.txt --test-ghci Main.main --command "cabal repl escalating-esqueleto-test"
+	ghciwatch \
+		--watch exercises \
+		--watch lib \
+		--watch answers \
+		--watch test \
+		--enable-eval \
+		--clear \
+		--error-file ghcid.txt \
+		--test-ghci Main.main \
+		--command "cabal repl escalating-esqueleto-test"
 
 .PHONY: test ghciwatch

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MAKEFLAGS += -s
+
 # check your exercises
 test:
 	cabal test

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,9 @@ db-reset:
 psql:
 	psql -d escalatingesqueleto
 
-# simple filewatcher that reruns `cabal test` on changes
-watch:
-	fswatch -o exercises/* lib/* answers/* test/* | (while read -r event; do cabal test; done)
 
 # close feedback loop with ghciwatch
 ghciwatch:
 	ghciwatch --watch exercises --watch lib --watch answers --watch test --enable-eval --clear --error-file ghcid.txt --test-ghci Main.main --command "cabal repl escalating-esqueleto-test"
 
-.PHONY: test watch ghciwatch
+.PHONY: test ghciwatch

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ make db-reset
 The first exercise file is `exercises/EE0_StartingOut.hs`
 
 1. Run `nix develop` to enter a nix shell
-2. Edit `test/Main.hs` to focus on the relevant tests (see below)
-3. Fix up the exercise file by filling in any typed holes or missing pieces
-4. In the nix shell, run `make test` to check your work
+2. In the nix shell, run `make ghciwatch` to start the feedback loop
+3. Edit `test/Main.hs` to focus on the relevant tests (see below)
+4. Fix up the exercise file by filling in any typed holes or missing pieces`
+5. Save the file; `ghciwatch` will automatically reload and rerun the relevant tests
 
 Then, move on to the next exercise file in `exercises/`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The first exercise file is `exercises/EE0_StartingOut.hs`
 1. Run `nix develop` to enter a nix shell
 2. In the nix shell, run `make ghciwatch` to start the feedback loop
 3. Edit `test/Main.hs` to focus on the relevant tests (see below)
-4. Fix up the exercise file by filling in any typed holes or missing pieces`
+4. Fix up the exercise file by filling in any typed holes or missing pieces
 5. Save the file; `ghciwatch` will automatically reload and rerun the relevant tests
 
 Then, move on to the next exercise file in `exercises/`

--- a/escalating-esqueleto.cabal
+++ b/escalating-esqueleto.cabal
@@ -10,20 +10,20 @@ maintainer:         mitchell@vitez.me
 common common-options
   ghc-options: -Wall -fdefer-typed-holes -fdiagnostics-color=always
   build-depends: base
-               , bytestring >= 0.11
-               , aeson >= 2.1
-               , esqueleto ^>=3.5
-               , monad-logger ^>=0.3
-               , mtl >= 2.3
+               , bytestring ^>= 0.12
+               , aeson ^>= 2.2
+               , esqueleto ^>= 3.5
+               , monad-logger ^>= 0.3
+               , mtl ^>= 2.3
                , path-pieces ^>=0.2
                , pcre-heavy ^>=1.0
                , persistent ^>=2.14
                , persistent-postgresql ^>=2.13
                , string-conversions ^>=0.4
-               , template-haskell >= 2.20
-               , text >= 2.0
-               , time >= 1.12
-               , uuid ^>=1.3
+               , template-haskell ^>= 2.22
+               , text ^>= 2.1
+               , time ^>= 1.12
+               , uuid ^>= 1.3
 
 library escalating-esqueleto-lib
   import: common-options

--- a/escalating-esqueleto.cabal
+++ b/escalating-esqueleto.cabal
@@ -8,7 +8,7 @@ author:             Mitchell Vitez
 maintainer:         mitchell@vitez.me
 
 common common-options
-  ghc-options: -Wall -fdefer-typed-holes
+  ghc-options: -Wall -fdefer-typed-holes -fdiagnostics-color=always
   build-depends: base
                , bytestring >= 0.11
                , aeson >= 2.1

--- a/escalating-esqueleto.cabal
+++ b/escalating-esqueleto.cabal
@@ -10,24 +10,24 @@ maintainer:         mitchell@vitez.me
 common common-options
   ghc-options: -Wall -fdefer-typed-holes
   build-depends: base
-               , bytestring ^>=0.11
-               , aeson ^>=2.1
+               , bytestring >= 0.11
+               , aeson >= 2.1
                , esqueleto ^>=3.5
                , monad-logger ^>=0.3
-               , mtl ^>=2.3
+               , mtl >= 2.3
                , path-pieces ^>=0.2
                , pcre-heavy ^>=1.0
                , persistent ^>=2.14
                , persistent-postgresql ^>=2.13
                , string-conversions ^>=0.4
-               , template-haskell ^>=2.20
-               , text ^>=2.0
-               , time ^>=1.12
+               , template-haskell >= 2.20
+               , text >= 2.0
+               , time >= 1.12
                , uuid ^>=1.3
 
 library escalating-esqueleto-lib
   import: common-options
-  ghc-options: -Wall -Werror -fdefer-typed-holes
+  ghc-options: -Wall -fdefer-typed-holes
   default-language: Haskell2010
   hs-source-dirs: lib
   exposed-modules: Schema
@@ -53,7 +53,7 @@ library escalating-esqueleto-exercises
 library escalating-esqueleto-answers
   import: common-options
   default-language: Haskell2010
-  ghc-options: -Wall -Werror -fdefer-typed-holes
+  ghc-options: -Wall -fdefer-typed-holes
   hs-source-dirs: answers
   exposed-modules: Answers
   build-depends: escalating-esqueleto-lib

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730045389,
-        "narHash": "sha256-4spSNTZ6h8Xmvrr9oqfuxc9jarasGj1QOcsgw8BfNd8=",
+        "lastModified": 1770781623,
+        "narHash": "sha256-RYEMTlGCVc67pxVxjOlGd8w6fpF7Bur7gKL88FB0WTs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fcb98acb6633445764dafe180e6833eb0f95208",
+        "rev": "c05d2232d2feaa4c7a07f1168606917402868195",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
               pkgs.pcre
               (pkgs.haskell-language-server.override { supportedGhcVersions = [ "96" ]; })
               pkgs.postgresql
-              pkgs.fswatch
               (pkgs.ghciwatch.overrideAttrs (oldAttrs: rec {
                 patches = oldAttrs.patches or [ ] ++ [
                   (pkgs.fetchpatch {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,14 @@
               (pkgs.haskell-language-server.override { supportedGhcVersions = [ "96" ]; })
               pkgs.postgresql
               pkgs.fswatch
+              (pkgs.ghciwatch.overrideAttrs (oldAttrs: rec {
+                patches = oldAttrs.patches or [ ] ++ [
+                  (pkgs.fetchpatch {
+                    url = "https://github.com/MercuryTechnologies/ghciwatch/commit/adb82ea1c7f8d7ce16b17f5f0fe530d5e832c300.patch";
+                    hash = "sha256-gbYr46nWLApKDCyGvv73fAIglc7qA3ydSXcgBpJIGWY=";
+                  })
+                ];
+              }))
             ];
             shellHook = ''
               export PGDATA=$PWD/.postgres

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
               }))
             ];
             shellHook = ''
+              export HSPEC_COLOR=always
+              export GHC_COLORS="always"
               export PGDATA=$PWD/.postgres
               export PGPORT=5432
               export PGHOST=/tmp

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,10 +10,11 @@ import Answers qualified as Answer
 import Types
 
 import Test.Hspec
+import Test.Hspec.Runner
 
 main :: IO ()
-main = hspec $ do
-  describe "EE0_StartingOut" $ do
+main = hspecWith defaultConfig { configColorMode = ColorAlways } $ do
+  fdescribe "EE0_StartingOut" $ do
     it "a_iWantToLearnEsqueleto" $ do
       Exercise.a_iWantToLearnEsqueleto `shouldBe` Answer.a_iWantToLearnEsqueleto
 


### PR DESCRIPTION
This PR adds support for `ghciwatch` to provide tighter feedback loops during Haskell development, compared to the currently existing `fswatch`.

Important changes:

### 1. `flake.nix`
- Apply the same specific patch of ghciwatch as LHbE, rather than the standard nix package

### 2. Makefile:
- `--clear`: Clears screen between runs for readability
- `--enable-eval`: Enables evaluation in REPL for faster feedback
- `--test-ghci Main.main`: Runs tests in REPL context

### 3. escalating-esqueleto.cabal
- Relaxed version constraints: Changed caret (^>=) to greater-than-or-equal (>=) for several core dependencies: `bytestring`, `aeson`, `mtl`, `template-haskell`, `text`, `time`
- Reasoning: Version constraint relaxation improves compatibility with ghciwatch's build environment and newer nixpkgs versions
